### PR TITLE
Added Cygwin check in os.h.

### DIFF
--- a/src/include/spdlog/details/os.h
+++ b/src/include/spdlog/details/os.h
@@ -236,7 +236,7 @@ inline size_t filesize(FILE *f)
 #else // unix
     int fd = fileno(f);
     //64 bits(but not in osx, where fstat64 is deprecated)
-#if !defined(__FreeBSD__) && !defined(__APPLE__) && (defined(__x86_64__) || defined(__ppc64__))
+#if !defined(__CYGWIN__) && !defined(__FreeBSD__) && !defined(__APPLE__) && (defined(__x86_64__) || defined(__ppc64__))
     struct stat64 st;
     if (fstat64(fd, &st) == 0)
         return static_cast<size_t>(st.st_size);


### PR DESCRIPTION
This seems to have fixed a build error when using cygwin on windows.  When combined with a modification to metaconfigure, Cygwin is able to build NJOY21 (using static libraries) and pass all tests.